### PR TITLE
[OG-52] Spring security

### DIFF
--- a/polymorphia-backend/pom.xml
+++ b/polymorphia-backend/pom.xml
@@ -52,6 +52,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/polymorphia-backend/src/main/java/com/agh/polymorphia_backend/config/SecurityConfig.java
+++ b/polymorphia-backend/src/main/java/com/agh/polymorphia_backend/config/SecurityConfig.java
@@ -1,0 +1,48 @@
+package com.agh.polymorphia_backend.config;
+
+import com.agh.polymorphia_backend.model.user.UserType;
+import com.agh.polymorphia_backend.service.UserService;
+import lombok.AllArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@AllArgsConstructor
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    private final UserService userService;
+
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(userService);
+        provider.setPasswordEncoder(passwordEncoder());
+        return provider;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+        return httpSecurity
+                .cors(Customizer.withDefaults())
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorizeRequests -> authorizeRequests
+                        .requestMatchers("/users", "/users/*").permitAll()
+                        .anyRequest().authenticated())
+                .formLogin(Customizer.withDefaults())
+                .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/polymorphia-backend/src/main/java/com/agh/polymorphia_backend/controller/UserController.java
+++ b/polymorphia-backend/src/main/java/com/agh/polymorphia_backend/controller/UserController.java
@@ -14,7 +14,7 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping()
-    public ResponseEntity<Void> addStudent(@RequestBody UserRequestDto userDto) {
+    public ResponseEntity<Void> addUser(@RequestBody UserRequestDto userDto) {
         Long userId = userService.addUser(userDto);
         return Util.getCreatedResponseEntity(userId);
     }

--- a/polymorphia-backend/src/main/java/com/agh/polymorphia_backend/dto/request/user/UserRequestDto.java
+++ b/polymorphia-backend/src/main/java/com/agh/polymorphia_backend/dto/request/user/UserRequestDto.java
@@ -1,6 +1,7 @@
 package com.agh.polymorphia_backend.dto.request.user;
 
 
+import com.agh.polymorphia_backend.model.user.UserType;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;

--- a/polymorphia-backend/src/main/java/com/agh/polymorphia_backend/dto/request/user/UserType.java
+++ b/polymorphia-backend/src/main/java/com/agh/polymorphia_backend/dto/request/user/UserType.java
@@ -1,7 +1,0 @@
-package com.agh.polymorphia_backend.dto.request.user;
-
-public enum UserType {
-    STUDENT,
-    INSTRUCTOR,
-    COORDINATOR
-}

--- a/polymorphia-backend/src/main/java/com/agh/polymorphia_backend/dto/response/user/UserResponseDto.java
+++ b/polymorphia-backend/src/main/java/com/agh/polymorphia_backend/dto/response/user/UserResponseDto.java
@@ -1,7 +1,7 @@
 package com.agh.polymorphia_backend.dto.response.user;
 
 
-import com.agh.polymorphia_backend.dto.request.user.UserType;
+import com.agh.polymorphia_backend.model.user.UserType;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;

--- a/polymorphia-backend/src/main/java/com/agh/polymorphia_backend/model/user/Coordinator.java
+++ b/polymorphia-backend/src/main/java/com/agh/polymorphia_backend/model/user/Coordinator.java
@@ -6,6 +6,10 @@ import jakarta.persistence.Table;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+import java.util.List;
 
 @Entity
 @SuperBuilder
@@ -14,4 +18,8 @@ import lombok.experimental.SuperBuilder;
 @Table(name = "coordinators")
 @PrimaryKeyJoinColumn(name = "user_id")
 public class Coordinator extends User {
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(UserType.COORDINATOR);
+    }
 }

--- a/polymorphia-backend/src/main/java/com/agh/polymorphia_backend/model/user/Instructor.java
+++ b/polymorphia-backend/src/main/java/com/agh/polymorphia_backend/model/user/Instructor.java
@@ -6,6 +6,10 @@ import jakarta.persistence.Table;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+import java.util.List;
 
 @Entity
 @SuperBuilder
@@ -14,5 +18,8 @@ import lombok.experimental.SuperBuilder;
 @Table(name = "instructors")
 @PrimaryKeyJoinColumn(name = "user_id")
 public class Instructor extends User {
-
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(UserType.INSTRUCTOR);
+    }
 }

--- a/polymorphia-backend/src/main/java/com/agh/polymorphia_backend/model/user/Student.java
+++ b/polymorphia-backend/src/main/java/com/agh/polymorphia_backend/model/user/Student.java
@@ -9,11 +9,14 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+import java.util.List;
 
 @Entity
 @Table(name = "students")
 @PrimaryKeyJoinColumn(name = "user_id")
-
 @Data
 @SuperBuilder
 @NoArgsConstructor
@@ -22,4 +25,9 @@ public class Student extends User {
     @NotNull
     @Column(unique = true)
     private Integer indexNumber;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(UserType.STUDENT);
+    }
 }

--- a/polymorphia-backend/src/main/java/com/agh/polymorphia_backend/model/user/User.java
+++ b/polymorphia-backend/src/main/java/com/agh/polymorphia_backend/model/user/User.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import org.springframework.security.core.userdetails.UserDetails;
 
 @Entity
 @Table(name = "users")
@@ -13,7 +14,7 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-public class User {
+public abstract class User implements UserDetails {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Setter(AccessLevel.NONE)
@@ -32,4 +33,9 @@ public class User {
 
     @NotEmpty
     private String password;
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
 }

--- a/polymorphia-backend/src/main/java/com/agh/polymorphia_backend/model/user/UserType.java
+++ b/polymorphia-backend/src/main/java/com/agh/polymorphia_backend/model/user/UserType.java
@@ -1,0 +1,14 @@
+package com.agh.polymorphia_backend.model.user;
+
+import org.springframework.security.core.GrantedAuthority;
+
+public enum UserType implements GrantedAuthority {
+    STUDENT,
+    INSTRUCTOR,
+    COORDINATOR;
+
+    @Override
+    public String getAuthority() {
+        return name();
+    }
+}

--- a/polymorphia-backend/src/main/java/com/agh/polymorphia_backend/repository/user/UserRepository.java
+++ b/polymorphia-backend/src/main/java/com/agh/polymorphia_backend/repository/user/UserRepository.java
@@ -4,4 +4,5 @@ import com.agh.polymorphia_backend.model.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    User findByEmail(String email);
 }

--- a/polymorphia-backend/src/main/java/com/agh/polymorphia_backend/service/UserService.java
+++ b/polymorphia-backend/src/main/java/com/agh/polymorphia_backend/service/UserService.java
@@ -7,17 +7,25 @@ import com.agh.polymorphia_backend.model.user.User;
 import com.agh.polymorphia_backend.repository.user.UserRepository;
 import com.agh.polymorphia_backend.service.mapper.UserMapper;
 import lombok.AllArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
 @AllArgsConstructor
-public class UserService {
+public class UserService implements UserDetailsService {
+    private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
     private static final String USER_NOT_FOUND = "User of id %s does not exist in the database";
     private final UserRepository userRepository;
     private final UserMapper userMapper;
 
     public Long addUser(UserRequestDto userRequestDto) {
         User user = userMapper.userRequestDtoToUser(userRequestDto);
+        user.setPassword(passwordEncoder.encode(userRequestDto.getPassword()));
         return userRepository.save(user).getId();
     }
 
@@ -25,5 +33,10 @@ public class UserService {
         User user = userRepository.findById(id).orElseThrow(() ->
                 new InvalidArgumentException(String.format(USER_NOT_FOUND, id)));
         return userMapper.userToUserResponseDto(user);
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        return userRepository.findByEmail(email);
     }
 }

--- a/polymorphia-backend/src/main/java/com/agh/polymorphia_backend/service/mapper/UserMapper.java
+++ b/polymorphia-backend/src/main/java/com/agh/polymorphia_backend/service/mapper/UserMapper.java
@@ -2,7 +2,7 @@ package com.agh.polymorphia_backend.service.mapper;
 
 import com.agh.polymorphia_backend.dto.request.user.StudentRequestDto;
 import com.agh.polymorphia_backend.dto.request.user.UserRequestDto;
-import com.agh.polymorphia_backend.dto.request.user.UserType;
+import com.agh.polymorphia_backend.model.user.UserType;
 import com.agh.polymorphia_backend.dto.response.user.CoordinatorResponseDto;
 import com.agh.polymorphia_backend.dto.response.user.InstructorResponseDto;
 import com.agh.polymorphia_backend.dto.response.user.StudentResponseDto;


### PR DESCRIPTION
- I moved `UserType` from `dto` package to `model` as it will now be used also for user roles.
- The `securityFilterChain` for now is really basic, and can't look like that in the future for sure. I let all requests to go to `/users` for now, to make it easy for us to add new users for tests. 

For requests that require authenticated users, you need to add `Authorization` header with token that is created by base64 encoding of string `<email>:<password>`. You may use for example: https://www.base64encode.org. Here is an examplary request:
```http
POST http://localhost:8080/rewards/chests
Content-Type: application/json
Authorization: Basic <token>

{
  "name": "chest1",
  "description": "description1",
  "imageUrl": "url1",
  "behavior": "ALL",
  "courseId": 1
}
```
