### PR TITLE
[OG-89] refactor Accordion to improve initial animation handling

### DIFF
--- a/polymorphia-frontend/animations/Accordion.tsx
+++ b/polymorphia-frontend/animations/Accordion.tsx
@@ -1,21 +1,21 @@
 import { gsap } from "gsap";
 
-export const openAccordion = (element: HTMLElement, instant: boolean) => {
+export const openAccordion = (element: HTMLElement, isInstant: boolean) => {
   gsap.to(element, {
     height: "auto",
     opacity: 1,
     marginTop: "0.5rem",
-    duration: instant ? 0.0 : 0.4,
+    duration: isInstant ? 0.0 : 0.4,
     ease: "power2.inOut",
   });
 };
 
-export const closeAccordion = (element: HTMLElement, instant: boolean) => {
+export const closeAccordion = (element: HTMLElement, isInstant: boolean) => {
   gsap.to(element, {
     height: 0,
     opacity: 0,
     marginTop: 0,
-    duration: instant ? 0.0 : 0.4,
+    duration: isInstant ? 0.0 : 0.4,
     ease: "power2.inOut",
   });
 };
@@ -23,11 +23,11 @@ export const closeAccordion = (element: HTMLElement, instant: boolean) => {
 export const animateAccordion = (
   element: HTMLElement,
   open: boolean,
-  instant: boolean = false
+  isInstant: boolean = false
 ) => {
   if (open) {
-    openAccordion(element, instant);
+    openAccordion(element, isInstant);
   } else {
-    closeAccordion(element, instant);
+    closeAccordion(element, isInstant);
   }
 };

--- a/polymorphia-frontend/animations/Accordion.tsx
+++ b/polymorphia-frontend/animations/Accordion.tsx
@@ -1,29 +1,33 @@
 import { gsap } from "gsap";
 
-export const openAccordion = (element: HTMLElement) => {
+export const openAccordion = (element: HTMLElement, instant: boolean) => {
   gsap.to(element, {
     height: "auto",
     opacity: 1,
     marginTop: "0.5rem",
-    duration: 0.4,
+    duration: instant ? 0.0 : 0.4,
     ease: "power2.inOut",
   });
 };
 
-export const closeAccordion = (element: HTMLElement) => {
+export const closeAccordion = (element: HTMLElement, instant: boolean) => {
   gsap.to(element, {
     height: 0,
     opacity: 0,
     marginTop: 0,
-    duration: 0.4,
+    duration: instant ? 0.0 : 0.4,
     ease: "power2.inOut",
   });
 };
 
-export const animateAccordion = (element: HTMLElement, open: boolean) => {
+export const animateAccordion = (
+  element: HTMLElement,
+  open: boolean,
+  instant: boolean = false
+) => {
   if (open) {
-    openAccordion(element);
+    openAccordion(element, instant);
   } else {
-    closeAccordion(element);
+    closeAccordion(element, instant);
   }
 };

--- a/polymorphia-frontend/components/accordion/Accordion.tsx
+++ b/polymorphia-frontend/components/accordion/Accordion.tsx
@@ -9,13 +9,14 @@ import { AccordionProps } from "./types";
 import clsx from "clsx";
 
 export const AccordionComponent = forwardRef<AccordionRef, AccordionProps>(
-  ({ children, className, maxOpen }, ref) => {
-    const accordionContext = useAccordionState(maxOpen);
+  ({ children, className, ...rest }, ref) => {
+    const accordionContext = useAccordionState(rest);
 
     useImperativeHandle(ref, () => ({
       open: accordionContext.open,
       close: accordionContext.close,
       closeAll: accordionContext.closeAll,
+      resetToInitial: accordionContext.resetToInitial,
       toggle: accordionContext.toggle,
     }));
 

--- a/polymorphia-frontend/components/accordion/AccordionSection.tsx
+++ b/polymorphia-frontend/components/accordion/AccordionSection.tsx
@@ -12,15 +12,20 @@ export default function AccordionSection({
   children,
   headerClassName,
 }: AccordionSectionProps) {
-  const { isOpen, toggle } = useAccordionContext();
+  const { isOpen, toggle, shouldAnimateInitialOpen } = useAccordionContext();
   const contentRef = useRef<HTMLDivElement>(null);
-
+  const isFirstRender = useRef(true);
   const isOpened = isOpen(id);
   useEffect(() => {
     if (contentRef.current) {
-      animateAccordion(contentRef.current, isOpened);
+      animateAccordion(
+        contentRef.current,
+        isOpened,
+        isFirstRender.current && !shouldAnimateInitialOpen
+      );
+      isFirstRender.current = false;
     }
-  }, [isOpened]);
+  }, [isOpened, shouldAnimateInitialOpen]);
 
   return (
     <div className="accordion-section">

--- a/polymorphia-frontend/components/accordion/AccordionSection.tsx
+++ b/polymorphia-frontend/components/accordion/AccordionSection.tsx
@@ -10,19 +10,10 @@ export default function AccordionSection({
   id,
   title,
   children,
-  isInitiallyOpened,
   headerClassName,
 }: AccordionSectionProps) {
-  const { register, unregister, isOpen, toggle, open } = useAccordionContext();
+  const { isOpen, toggle } = useAccordionContext();
   const contentRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    register(id);
-    if (isInitiallyOpened) {
-      open(id);
-    }
-    return () => unregister(id);
-  }, [id, isInitiallyOpened, open, register, unregister]);
 
   const isOpened = isOpen(id);
   useEffect(() => {

--- a/polymorphia-frontend/components/accordion/index.css
+++ b/polymorphia-frontend/components/accordion/index.css
@@ -13,7 +13,7 @@
     @apply flex justify-between items-center;
 
     h1 {
-        @apply text-3xl;
+        @apply text-3xl truncate;
     }
 }
 

--- a/polymorphia-frontend/components/accordion/types.ts
+++ b/polymorphia-frontend/components/accordion/types.ts
@@ -1,8 +1,8 @@
+import { useAccordionStateProps } from "@/providers/accordion/types";
 import { ReactNode } from "react";
 
-export interface AccordionProps {
+export interface AccordionProps extends useAccordionStateProps {
   children: ReactNode;
-  maxOpen?: number;
   className?: string;
 }
 
@@ -10,6 +10,5 @@ export interface AccordionSectionProps {
   id: string;
   title: string;
   children: ReactNode;
-  isInitiallyOpened?: boolean;
   headerClassName?: string;
 }

--- a/polymorphia-frontend/components/filters/modals/FiltersModal.tsx
+++ b/polymorphia-frontend/components/filters/modals/FiltersModal.tsx
@@ -41,7 +41,6 @@ export default function FiltersModal<FilterIdType extends string>({
 
     if (result.ok) {
       onFiltersApplied?.();
-      accordionRef.current?.closeAll();
       setIsModalOpen(false);
     } else if (result.errors !== undefined) {
       (Object.keys(result.errors) as FilterIdType[]).forEach(
@@ -65,6 +64,10 @@ export default function FiltersModal<FilterIdType extends string>({
       <>
         <Accordion
           ref={accordionRef}
+          sectionIds={new Set(configs.map(({ id }) => id))}
+          initiallyOpenedSectionIds={
+            new Set(configs.length > 0 ? [configs[0].id] : [])
+          }
           maxOpen={1}
           className="filters-modal-wrapper"
         >
@@ -111,7 +114,7 @@ export default function FiltersModal<FilterIdType extends string>({
       isDataPresented={isModalOpen}
       title="Filtry"
       onClosed={() => {
-        accordionRef.current?.closeAll();
+        accordionRef.current?.resetToInitial();
         resetFiltersToApplied();
         setIsModalOpen(false);
       }}

--- a/polymorphia-frontend/components/filters/modals/FiltersModal.tsx
+++ b/polymorphia-frontend/components/filters/modals/FiltersModal.tsx
@@ -118,6 +118,7 @@ export default function FiltersModal<FilterIdType extends string>({
         resetFiltersToApplied();
         setIsModalOpen(false);
       }}
+      shouldUnmountWhenClosed={true}
     >
       <div className="filters-modal">{getModalContent()}</div>
     </Modal>

--- a/polymorphia-frontend/components/filters/modals/FiltersModal.tsx
+++ b/polymorphia-frontend/components/filters/modals/FiltersModal.tsx
@@ -60,14 +60,18 @@ export default function FiltersModal<FilterIdType extends string>({
       return <h1>Nie udało się załadować filtrów.</h1>;
     }
 
+    const filterIds = configs.map(({ id }) => id);
+    const accordionSections = new Set(filterIds);
+    const initiallyOpenedAccordionSections = new Set(
+      filterIds.length > 0 ? [filterIds[0]] : []
+    );
+
     return (
       <>
         <Accordion
           ref={accordionRef}
-          sectionIds={new Set(configs.map(({ id }) => id))}
-          initiallyOpenedSectionIds={
-            new Set(configs.length > 0 ? [configs[0].id] : [])
-          }
+          sectionIds={accordionSections}
+          initiallyOpenedSectionIds={initiallyOpenedAccordionSections}
           maxOpen={1}
           className="filters-modal-wrapper"
         >

--- a/polymorphia-frontend/components/grading-components/grade/index.tsx
+++ b/polymorphia-frontend/components/grading-components/grade/index.tsx
@@ -34,11 +34,19 @@ export default function Grade() {
       );
     }
 
+    const accordionSections = [...Object.keys(state.criteria), "Komentarz"];
+
     return (
       <Fragment key={getKeyForSelectedTarget(state)}>
         <Accordion
           ref={accordionRef}
           className="grade-accordion-override"
+          sectionIds={new Set(accordionSections)}
+          initiallyOpenedSectionIds={
+            new Set(
+              accordionSections.length > 0 && isXL ? [accordionSections[0]] : []
+            )
+          }
           maxOpen={1}
         >
           {Object.entries(state.criteria).map(
@@ -57,7 +65,6 @@ export default function Grade() {
                   id={criterionId}
                   title={criterion.name}
                   headerClassName="grading-accordion-header"
-                  isInitiallyOpened={index == 0 && isXL}
                 >
                   <div key={criterionId} className="grade-criterion">
                     <div className="grade-criterion-progress-bar">

--- a/polymorphia-frontend/components/grading-components/grade/index.tsx
+++ b/polymorphia-frontend/components/grading-components/grade/index.tsx
@@ -48,6 +48,7 @@ export default function Grade() {
             )
           }
           maxOpen={1}
+          shouldAnimateInitialOpen={false}
         >
           {Object.entries(state.criteria).map(
             ([criterionId, criterionGrade], index) => {

--- a/polymorphia-frontend/components/grading-components/grade/index.tsx
+++ b/polymorphia-frontend/components/grading-components/grade/index.tsx
@@ -51,7 +51,7 @@ export default function Grade() {
           shouldAnimateInitialOpen={false}
         >
           {Object.entries(state.criteria).map(
-            ([criterionId, criterionGrade], index) => {
+            ([criterionId, criterionGrade]) => {
               const criterion = criteria?.find(
                 (criterion) => criterion.id === Number(criterionId)
               );

--- a/polymorphia-frontend/components/grading-components/grade/index.tsx
+++ b/polymorphia-frontend/components/grading-components/grade/index.tsx
@@ -2,7 +2,7 @@
 
 import "../../../views/course/grading/index.css";
 import "./index.css";
-import { ReactNode, useRef } from "react";
+import { Fragment, ReactNode, useRef } from "react";
 import ProgressBar from "@/components/progressbar/ProgressBar";
 import ProgressBarRangeLabels from "@/components/progressbar/ProgressBarRangeLabels";
 import ButtonWithBorder from "@/components/button/ButtonWithBorder";
@@ -16,6 +16,7 @@ import Comment from "@/components/grading-components/grade/Comment";
 import Input from "@/components/grading-components/grade/Input";
 import useGradingContext from "@/hooks/contexts/useGradingContext";
 import { useMediaQuery } from "react-responsive";
+import { getKeyForSelectedTarget } from "@/providers/grading/utils/getKeyForSelectedTarget";
 
 export default function Grade() {
   const { state, criteria, isGradeLoading, submitGrade } = useGradingContext();
@@ -34,7 +35,7 @@ export default function Grade() {
     }
 
     return (
-      <>
+      <Fragment key={getKeyForSelectedTarget(state)}>
         <Accordion
           ref={accordionRef}
           className="grade-accordion-override"
@@ -105,7 +106,7 @@ export default function Grade() {
             onClick={submitGrade}
           />
         </div>
-      </>
+      </Fragment>
     );
   };
 

--- a/polymorphia-frontend/components/grading-components/grading-wrapper/index.css
+++ b/polymorphia-frontend/components/grading-components/grading-wrapper/index.css
@@ -2,13 +2,13 @@
 @import "../../../styles/globals.css";
 
 .grading-wrapper {
-    @apply w-full overflow-y-hidden flex flex-col gap-y-4 min-h-0;
+    @apply w-full overflow-y-hidden flex flex-col gap-y-4 min-h-0 min-w-0;
 }
 
 .grading-wrapper-top {
-    @apply w-full flex justify-between items-center px-8 mx-auto min-h-12;
+    @apply w-full flex justify-between items-center px-8 mx-auto min-h-12 min-w-0;
 }
 
 .grading-wrapper-main {
-    @apply w-full flex flex-col relative px-8 py-4 mx-auto custom-scrollbar flex-1 min-h-0 overflow-y-auto;
+    @apply w-full flex flex-col relative px-8 py-4 mx-auto custom-scrollbar flex-1 min-h-0 overflow-y-auto min-w-0;
 }

--- a/polymorphia-frontend/components/grading-components/pull-request/index.tsx
+++ b/polymorphia-frontend/components/grading-components/pull-request/index.tsx
@@ -16,14 +16,23 @@ export default function PullRequest({ pullRequests }: PullRequestProps) {
   const topComponent = <h1 className="text-5xl">Pull Request</h1>;
 
   const mainComponent = (): ReactNode => (
-    <Accordion ref={accordionRef} className="gap-y-5" maxOpen={2}>
+    <Accordion
+      ref={accordionRef}
+      className="gap-y-5"
+      sectionIds={new Set(pullRequests.map(({ name }) => String(name)))}
+      initiallyOpenedSectionIds={
+        new Set(
+          pullRequests.length > 0 && isXL ? [String(pullRequests[0].name)] : []
+        )
+      }
+      maxOpen={2}
+    >
       {pullRequests.map((pullRequest, index) => (
         <AccordionSection
           key={index}
           id={pullRequest.name}
           title={pullRequest.name}
           headerClassName="grading-accordion-header"
-          isInitiallyOpened={index === 0 && isXL}
         >
           <div key={index} className="flex flex-col mb-3">
             <h3 className="text-2xl mb-2 hover:cursor-pointer">

--- a/polymorphia-frontend/components/grading-components/pull-request/index.tsx
+++ b/polymorphia-frontend/components/grading-components/pull-request/index.tsx
@@ -15,16 +15,18 @@ export default function PullRequest({ pullRequests }: PullRequestProps) {
 
   const topComponent = <h1 className="text-5xl">Pull Request</h1>;
 
+  const pullRequestNames = pullRequests.map(({ name }) => String(name));
+  const accordionSections = new Set(pullRequestNames);
+  const initiallyOpenedAccordionSections = new Set(
+    pullRequestNames.length > 0 && isXL ? [pullRequestNames[0]] : []
+  );
+
   const mainComponent = (): ReactNode => (
     <Accordion
       ref={accordionRef}
       className="gap-y-5"
-      sectionIds={new Set(pullRequests.map(({ name }) => String(name)))}
-      initiallyOpenedSectionIds={
-        new Set(
-          pullRequests.length > 0 && isXL ? [String(pullRequests[0].name)] : []
-        )
-      }
+      sectionIds={accordionSections}
+      initiallyOpenedSectionIds={initiallyOpenedAccordionSections}
       maxOpen={2}
     >
       {pullRequests.map((pullRequest, index) => (

--- a/polymorphia-frontend/components/modal/Modal.tsx
+++ b/polymorphia-frontend/components/modal/Modal.tsx
@@ -11,8 +11,15 @@ import { ModalProps } from "@/components/modal/types";
 import { useTheme } from "next-themes";
 
 export default function Modal(props: ModalProps) {
-  const { isDataPresented, onClosed, title, subtitle, children, ...rest } =
-    props;
+  const {
+    isDataPresented,
+    onClosed,
+    title,
+    subtitle,
+    children,
+    shouldUnmountWhenClosed = false,
+    ...rest
+  } = props;
 
   const [modalVisible, setModalVisible] = useState(false);
   const modalRef = useRef<HTMLDivElement | null>(null);
@@ -67,7 +74,7 @@ export default function Modal(props: ModalProps) {
               </div>
               <h2>{subtitle}</h2>
             </div>
-            {children}
+            {(!shouldUnmountWhenClosed || modalState !== "closed") && children}
           </div>
         </div>,
         document.body

--- a/polymorphia-frontend/components/modal/types.ts
+++ b/polymorphia-frontend/components/modal/types.ts
@@ -8,4 +8,5 @@ export interface ModalProps {
   title: string;
   subtitle?: string;
   children?: ReactNode;
+  shouldUnmountWhenClosed?: boolean;
 }

--- a/polymorphia-frontend/providers/accordion/AccordionContext.tsx
+++ b/polymorphia-frontend/providers/accordion/AccordionContext.tsx
@@ -10,6 +10,7 @@ export function useAccordionState({
   sectionIds,
   initiallyOpenedSectionIds = new Set(),
   maxOpen,
+  shouldAnimateInitialOpen = true,
 }: useAccordionStateProps): AccordionContextInterface {
   const [openSections, setOpenSections] = useState<string[]>(() =>
     getInitialOpenSections(sectionIds, initiallyOpenedSectionIds, maxOpen)
@@ -77,5 +78,13 @@ export function useAccordionState({
     [openSections]
   );
 
-  return { open, close, closeAll, resetToInitial, toggle, isOpen };
+  return {
+    open,
+    close,
+    closeAll,
+    resetToInitial,
+    toggle,
+    isOpen,
+    shouldAnimateInitialOpen,
+  };
 }

--- a/polymorphia-frontend/providers/accordion/AccordionContext.tsx
+++ b/polymorphia-frontend/providers/accordion/AccordionContext.tsx
@@ -1,26 +1,29 @@
-import { createContext, useCallback, useRef, useState } from "react";
-import { AccordionContextInterface } from "./types";
+import { createContext, useCallback, useEffect, useState } from "react";
+import { AccordionContextInterface, useAccordionStateProps } from "./types";
+import { getInitialOpenSections } from "./utils/getInitialOpenSections";
 
 export const AccordionContext = createContext<
   AccordionContextInterface | undefined
 >(undefined);
 
-export function useAccordionState(maxOpen?: number): AccordionContextInterface {
-  const [openSections, setOpenSections] = useState<string[]>([]);
-  const registeredIds = useRef<Set<string>>(new Set());
+export function useAccordionState({
+  sectionIds,
+  initiallyOpenedSectionIds = new Set(),
+  maxOpen,
+}: useAccordionStateProps): AccordionContextInterface {
+  const [openSections, setOpenSections] = useState<string[]>(() =>
+    getInitialOpenSections(sectionIds, initiallyOpenedSectionIds, maxOpen)
+  );
 
-  const register = useCallback((id: string) => {
-    registeredIds.current.add(id);
-  }, []);
-
-  const unregister = useCallback((id: string) => {
-    registeredIds.current.delete(id);
-    setOpenSections((prev) => prev.filter((sectionId) => sectionId !== id));
-  }, []);
+  useEffect(() => {
+    setOpenSections((prev) =>
+      prev.filter((sectionId) => sectionIds.has(sectionId))
+    );
+  }, [sectionIds]);
 
   const open = useCallback(
     (id: string) => {
-      if (!registeredIds.current.has(id)) {
+      if (!sectionIds.has(id)) {
         console.warn(`[Accordion] Tried to open invalid id "${id}"`);
         return;
       }
@@ -34,20 +37,29 @@ export function useAccordionState(maxOpen?: number): AccordionContextInterface {
         return [...prev, id];
       });
     },
-    [maxOpen]
+    [maxOpen, sectionIds]
   );
 
-  const close = useCallback((id: string) => {
-    if (!registeredIds.current.has(id)) {
-      console.warn(`[Accordion] Tried to close invalid id "${id}"`);
-      return;
-    }
-    setOpenSections((prev) => prev.filter((sectionId) => sectionId !== id));
-  }, []);
+  const close = useCallback(
+    (id: string) => {
+      if (!sectionIds.has(id)) {
+        console.warn(`[Accordion] Tried to close invalid id "${id}"`);
+        return;
+      }
+      setOpenSections((prev) => prev.filter((sectionId) => sectionId !== id));
+    },
+    [sectionIds]
+  );
 
   const closeAll = useCallback(() => {
     setOpenSections([]);
   }, []);
+
+  const resetToInitial = useCallback(() => {
+    setOpenSections(
+      getInitialOpenSections(sectionIds, initiallyOpenedSectionIds, maxOpen)
+    );
+  }, [initiallyOpenedSectionIds, maxOpen, sectionIds]);
 
   const toggle = useCallback(
     (id: string) => {
@@ -65,5 +77,5 @@ export function useAccordionState(maxOpen?: number): AccordionContextInterface {
     [openSections]
   );
 
-  return { open, close, closeAll, toggle, isOpen, register, unregister };
+  return { open, close, closeAll, resetToInitial, toggle, isOpen };
 }

--- a/polymorphia-frontend/providers/accordion/types.ts
+++ b/polymorphia-frontend/providers/accordion/types.ts
@@ -4,11 +4,16 @@ export interface AccordionRef {
   open: AccordionAction<void>;
   close: AccordionAction<void>;
   closeAll: () => void;
+  resetToInitial: () => void;
   toggle: AccordionAction<void>;
 }
 
 export interface AccordionContextInterface extends AccordionRef {
-  register: AccordionAction<void>;
-  unregister: AccordionAction<void>;
   isOpen: AccordionAction<boolean>;
+}
+
+export interface useAccordionStateProps {
+  sectionIds: Set<string>;
+  initiallyOpenedSectionIds?: Set<string>;
+  maxOpen?: number;
 }

--- a/polymorphia-frontend/providers/accordion/types.ts
+++ b/polymorphia-frontend/providers/accordion/types.ts
@@ -10,10 +10,12 @@ export interface AccordionRef {
 
 export interface AccordionContextInterface extends AccordionRef {
   isOpen: AccordionAction<boolean>;
+  shouldAnimateInitialOpen: boolean;
 }
 
 export interface useAccordionStateProps {
   sectionIds: Set<string>;
   initiallyOpenedSectionIds?: Set<string>;
   maxOpen?: number;
+  shouldAnimateInitialOpen?: boolean;
 }

--- a/polymorphia-frontend/providers/accordion/utils/getInitialOpenSections.ts
+++ b/polymorphia-frontend/providers/accordion/utils/getInitialOpenSections.ts
@@ -6,7 +6,7 @@ export function getInitialOpenSections(
     useAccordionStateProps["initiallyOpenedSectionIds"]
   >,
   maxOpen: useAccordionStateProps["maxOpen"]
-) {
+): string[] {
   if (initiallyOpenedSectionIds.difference(sectionIds).size > 0) {
     console.warn(
       `[Accordion] Initially opened sections contain invalid id(s).`

--- a/polymorphia-frontend/providers/accordion/utils/getInitialOpenSections.ts
+++ b/polymorphia-frontend/providers/accordion/utils/getInitialOpenSections.ts
@@ -1,0 +1,19 @@
+import { useAccordionStateProps } from "../types";
+
+export function getInitialOpenSections(
+  sectionIds: useAccordionStateProps["sectionIds"],
+  initiallyOpenedSectionIds: NonNullable<
+    useAccordionStateProps["initiallyOpenedSectionIds"]
+  >,
+  maxOpen: useAccordionStateProps["maxOpen"]
+) {
+  if (initiallyOpenedSectionIds.difference(sectionIds).size > 0) {
+    console.warn(
+      `[Accordion] Initially opened sections contain invalid id(s).`
+    );
+  }
+
+  return Array.from(
+    initiallyOpenedSectionIds.intersection<string>(sectionIds).keys()
+  ).slice(0, maxOpen ?? sectionIds.size);
+}

--- a/polymorphia-frontend/providers/grading/utils/getKeyForSelectedTarget.ts
+++ b/polymorphia-frontend/providers/grading/utils/getKeyForSelectedTarget.ts
@@ -1,0 +1,11 @@
+import { GradingReducerState } from "../GradingContext";
+
+export function getKeyForSelectedTarget(
+  state: GradingReducerState
+): string | undefined {
+  if (state.selectedTarget === null) {
+    return undefined;
+  }
+
+  return state.selectedTarget.map(({ id }) => String(id)).join("_");
+}

--- a/polymorphia-frontend/providers/grading/utils/getKeyForSelectedTarget.ts
+++ b/polymorphia-frontend/providers/grading/utils/getKeyForSelectedTarget.ts
@@ -1,4 +1,4 @@
-import { GradingReducerState } from "../GradingContext";
+import { GradingReducerState } from "@/providers/grading/GradingContext";
 
 export function getKeyForSelectedTarget(
   state: GradingReducerState

--- a/polymorphia-frontend/tsconfig.json
+++ b/polymorphia-frontend/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -24,18 +20,9 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./*"
-      ]
+      "@/*": ["./*"]
     }
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
 }

--- a/polymorphia-frontend/views/course/grading/index.css
+++ b/polymorphia-frontend/views/course/grading/index.css
@@ -25,6 +25,6 @@
 }
 
 .grading-columns {
-    @apply w-full max-w-md flex flex-col gap-y-4 h-fit min-h-0;
+    @apply w-full max-w-md flex flex-col gap-y-4 h-fit min-h-0 min-w-0;
 }
 


### PR DESCRIPTION
- ensures consistent animation behavior in Grade component
- refactors Accodrion logic to avoid initial flash ("Otwórz" instead of "Zamknij" would show up for a split second)
- adds prop to control if initial open should be animated
- adds possibility to unmount children when Modal is closed to allow initial Accordion animation on modal open

Even though this API is a little bit trickier to use, it avoids awkward registering logic that caused initial flash. I think that this trade-off is really worth it.

I did not handle Pull Requests section of Grading as it will be better to handle animation with the entire logic for submissions at the same time (in order not to introduce unnecessary code now).

https://github.com/user-attachments/assets/ba1034a6-c826-492a-adac-1f271a047a93

https://github.com/user-attachments/assets/15766d20-d0b0-425c-891f-41a087352aaa
