### PR TITLE
[FIX] assigned rewards not updating after quantity change

### DIFF
--- a/polymorphia-frontend/components/grading-components/grade/criteria/index.tsx
+++ b/polymorphia-frontend/components/grading-components/grade/criteria/index.tsx
@@ -71,8 +71,8 @@ export default function GradeCriteria({ criteria }: GradeCriteriaProps) {
                   duration={0.3}
                   keyProp={
                     criterionGrade && !isGradeLoading
-                      ? "loading" + getKeyForSelectedTarget(state)
-                      : getKeyForSelectedTarget(state)
+                      ? getKeyForSelectedTarget(state)
+                      : "loading" + getKeyForSelectedTarget(state)
                   }
                 >
                   {criterionGrade && !isGradeLoading ? (
@@ -104,8 +104,8 @@ export default function GradeCriteria({ criteria }: GradeCriteriaProps) {
               duration={0.3}
               keyProp={
                 !isGradeLoading
-                  ? "loading" + getKeyForSelectedTarget(state)
-                  : getKeyForSelectedTarget(state)
+                  ? getKeyForSelectedTarget(state)
+                  : "loading" + getKeyForSelectedTarget(state)
               }
             >
               {!isGradeLoading ? (


### PR DESCRIPTION
During our recent meeting, I noticed a bug when changing the quantity of assigned item in grading - the value did not change at all until you resized the viewport and caused the entire grading component to refresh. It is due to an oversight in previous `SwapAnimationWrapper` implementation - if the component changed (because the quantity of the item changed) but the key stayed the same, it would not allow to change the component.

Now, `SwapAnimationWrapper` handles correctly any changes to the component rendered and allows for skipping animation if key hasn't changed.

<details>
<summary>Details</summary>
please don't ask me how this works i beg you please don't ask me how this works i beg you please don't ask me how this works i beg you please don't ask me how this works i beg you please don't ask me how this works i beg you please don't ask me how this works i beg you please don't ask me how this works i beg you please don't ask me how this works i beg you please don't ask me how this works i beg you please don't ask me how this works i beg you please don't ask me how this works i beg you please don't ask me how this works i beg you please don't ask me how this works i beg you please don't ask me how this works i beg you please don't ask me how this works i beg you please don't ask me how this works i beg you please don't ask me how this works i beg you please don't ask me how this works i beg you please don't ask me how this works i beg you please don't ask me how this works i beg you please don't ask me how this works i beg you please don't ask me how this works i beg you please don't ask me how this works i beg you please don't ask me how this works i beg you 

<img width="686" height="386" alt="obraz" src="https://github.com/user-attachments/assets/34a337c9-7f93-42a2-b0d0-b044d93cba54" />

funny cat yay

</details>
