### PR TITLE
[OG-148] filters in local storage

### DIFF
--- a/polymorphia-frontend/hooks/course/filters/useFilters/index.tsx
+++ b/polymorphia-frontend/hooks/course/filters/useFilters/index.tsx
@@ -8,9 +8,12 @@ import {
 import { filterReducer } from "@/hooks/course/filters/useFilters/utils/filterReducer";
 import { getInitialState } from "@/hooks/course/filters/useFilters/utils/getInitialState";
 import { validateFilters } from "@/hooks/course/filters/useFilters/utils/validateFilters";
+import { readFiltersFromLocalStorage } from "./utils/readFiltersFromLocalStorage";
+import { saveFiltersToLocalStorage } from "./utils/saveFiltersToLocalStorage";
 
 export function useFilters<FilterIdType extends string>(
-  configs: FilterConfig<FilterIdType>[]
+  configs: FilterConfig<FilterIdType>[],
+  localStorageKey?: string
 ) {
   const reducer = (
     state: FilterState<FilterIdType>,
@@ -30,13 +33,28 @@ export function useFilters<FilterIdType extends string>(
     if (configs.length > 0) {
       dispatch({ type: FilterActions.RESET });
       setAppliedState(getInitialState<FilterIdType>(configs));
+      if (localStorageKey !== undefined) {
+        const newState = readFiltersFromLocalStorage(
+          appliedState,
+          configs,
+          localStorageKey
+        );
+        if (newState !== null) {
+          setAppliedState(newState);
+          dispatch({ type: FilterActions.SET, state: newState });
+        }
+      }
     }
-  }, [configs]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- We want to run this effect only on config change or key change.
+  }, [configs, localStorageKey]);
 
   const applyFilters = () => {
     const { valid, errors } = validateFilters(state, configs);
     if (valid) {
       setAppliedState(state);
+      if (localStorageKey !== undefined) {
+        saveFiltersToLocalStorage(state, localStorageKey);
+      }
       return { ok: true };
     }
     return { ok: false, errors };

--- a/polymorphia-frontend/hooks/course/filters/useFilters/index.tsx
+++ b/polymorphia-frontend/hooks/course/filters/useFilters/index.tsx
@@ -8,8 +8,8 @@ import {
 import { filterReducer } from "@/hooks/course/filters/useFilters/utils/filterReducer";
 import { getInitialState } from "@/hooks/course/filters/useFilters/utils/getInitialState";
 import { validateFilters } from "@/hooks/course/filters/useFilters/utils/validateFilters";
-import { readFiltersFromLocalStorage } from "./utils/readFiltersFromLocalStorage";
-import { saveFiltersToLocalStorage } from "./utils/saveFiltersToLocalStorage";
+import { readFiltersFromLocalStorage } from "@/hooks/course/filters/useFilters/utils/readFiltersFromLocalStorage";
+import { saveFiltersToLocalStorage } from "@/hooks/course/filters/useFilters/utils/saveFiltersToLocalStorage";
 
 export function useFilters<FilterIdType extends string>(
   configs: FilterConfig<FilterIdType>[],

--- a/polymorphia-frontend/hooks/course/filters/useFilters/utils/readFiltersFromLocalStorage.ts
+++ b/polymorphia-frontend/hooks/course/filters/useFilters/utils/readFiltersFromLocalStorage.ts
@@ -1,0 +1,44 @@
+import {
+  FilterConfig,
+  FilterState,
+} from "@/hooks/course/filters/useFilters/types";
+
+export function readFiltersFromLocalStorage<FilterIdType extends string>(
+  appliedState: FilterState<FilterIdType>,
+  configs: FilterConfig<FilterIdType>[],
+  key: string
+): FilterState<FilterIdType> | null {
+  const localStorageData = localStorage.getItem("filters_" + key);
+  if (localStorageData === null) {
+    return null;
+  }
+
+  const localStorageFilterState: FilterState<FilterIdType> =
+    JSON.parse(localStorageData);
+
+  let validNewFilterState = {};
+  configs.forEach((config) => {
+    if (!(config.id in localStorageFilterState)) {
+      return;
+    }
+
+    const validOptions: string[] = localStorageFilterState[config.id].filter(
+      (localStorageOption) =>
+        config.options.some((option) => option.value === localStorageOption)
+    );
+
+    if (validOptions.length > 0) {
+      validNewFilterState = {
+        ...validNewFilterState,
+        [config.id]: validOptions,
+      };
+    }
+  });
+
+  const newState = {
+    ...appliedState,
+    ...validNewFilterState,
+  };
+
+  return newState;
+}

--- a/polymorphia-frontend/hooks/course/filters/useFilters/utils/saveFiltersToLocalStorage.ts
+++ b/polymorphia-frontend/hooks/course/filters/useFilters/utils/saveFiltersToLocalStorage.ts
@@ -1,0 +1,8 @@
+import { FilterState } from "@/hooks/course/filters/useFilters/types";
+
+export function saveFiltersToLocalStorage<FilterIdType extends string>(
+  appliedState: FilterState<FilterIdType>,
+  key: string
+) {
+  localStorage.setItem("filters_" + key, JSON.stringify(appliedState));
+}

--- a/polymorphia-frontend/providers/course-groups/index.tsx
+++ b/polymorphia-frontend/providers/course-groups/index.tsx
@@ -24,7 +24,10 @@ export const CourseGroupsProvider = ({ children }: { children: ReactNode }) => {
   const [gradableEventId, setGradableEventId] = useState<number | null>(null);
   const [areFiltersOpen, setAreFiltersOpen] = useState(false);
   const filterConfigs = useCourseGroupsFilterConfigs();
-  const filters = useFilters<CourseGroupsFilterId>(filterConfigs ?? []);
+  const filters = useFilters<CourseGroupsFilterId>(
+    filterConfigs ?? [],
+    "courseGroups"
+  );
   const sortBy = useMemo(
     () => filters.getAppliedFilterValues("sortBy") ?? DEFAULT_SORT_BY_TOTAL,
     [filters]

--- a/polymorphia-frontend/providers/grading/index.tsx
+++ b/polymorphia-frontend/providers/grading/index.tsx
@@ -48,7 +48,7 @@ export const GradingProvider = ({ children }: { children: ReactNode }) => {
     isError: isFiltersError,
   } = useGradingFilterConfigs(gradableEventId);
 
-  const filters = useFilters<GradingFilterId>(filterConfigs ?? []);
+  const filters = useFilters<GradingFilterId>(filterConfigs ?? [], "grading");
   const searchBy = useMemo(
     () => filters.getAppliedFilterValues("searchBy") ?? DEFAULT_SEARCH_BY,
     [filters]

--- a/polymorphia-frontend/providers/hall-of-fame/index.tsx
+++ b/polymorphia-frontend/providers/hall-of-fame/index.tsx
@@ -51,7 +51,10 @@ export const HallOfFameProvider = ({ children }: { children: ReactNode }) => {
     isLoading: isFiltersLoading,
     isError: isFiltersError,
   } = useHallOfFameFilterConfigs(courseId);
-  const filters = useFilters<HallOfFameFilterId>(filterConfigs ?? []);
+  const filters = useFilters<HallOfFameFilterId>(
+    filterConfigs ?? [],
+    "hallOfFame"
+  );
 
   const sortByFilterValues = useMemo(
     () => filters.getAppliedFilterValues("sortBy") ?? DEFAULT_SORT_BY_TOTAL,

--- a/polymorphia-frontend/providers/profile/index.tsx
+++ b/polymorphia-frontend/providers/profile/index.tsx
@@ -21,7 +21,7 @@ export const ProfileProvider = ({ children }: { children: ReactNode }) => {
     isLoading: isFiltersLoading,
     isError: isFiltersError,
   } = useProfileFilterConfigs();
-  const filters = useFilters<ProfileFilterId>(filterConfigs ?? []);
+  const filters = useFilters<ProfileFilterId>(filterConfigs ?? [], "profile");
   const lastEvolutionStageId = profile
     ? profile.evolutionStageThresholds.length - 1
     : 0;

--- a/polymorphia-frontend/providers/project-group-configuration/index.tsx
+++ b/polymorphia-frontend/providers/project-group-configuration/index.tsx
@@ -38,7 +38,8 @@ export function ProjectGroupConfigurationProvider({
   } = useProjectGroupConfigurationFilterConfigs(initialTarget);
 
   const filters = useFilters<ProjectGroupConfigurationFilterId>(
-    filterConfigs ?? []
+    filterConfigs ?? [],
+    "projectGroupConfiguration"
   );
 
   const {


### PR DESCRIPTION
Adds support for storing filters from `useFilters` in `localStorage`. You need to provide a key for `useFilters` to activate the feature. It updates the filters if they are valid compared to filter configs, if not, default value from config is used.

Currently, I used section names as keys, therefore e.g. every gradable event in grading will use the same cached filters. We can change to it be gradable event specific by adding gradable event id to key but I don't think that we should (let me know what you think).

Filters are not shared between categories (e.g. course groups and grading) but I think that it makes sense to separate them as they have different filters.