### PR TITLE
[I-225] Error handling

### DIFF
--- a/polymorphia-frontend/app/layout.tsx
+++ b/polymorphia-frontend/app/layout.tsx
@@ -62,10 +62,10 @@ export default function RootLayout({
       return;
     }
 
-    const qc = queryClientRef.current;
-    if (qc && (error.status === 401 || error.status === 503)) {
-      await qc.cancelQueries({ predicate: () => true });
-      await qc.resetQueries({ predicate: () => true });
+    const currentQueryClient = queryClientRef.current;
+    if (currentQueryClient && (error.status === 401 || error.status === 503)) {
+      await currentQueryClient.cancelQueries({ predicate: () => true });
+      await currentQueryClient.resetQueries({ predicate: () => true });
     }
 
     if (error.status === 401) {

--- a/polymorphia-frontend/app/layout.tsx
+++ b/polymorphia-frontend/app/layout.tsx
@@ -5,7 +5,7 @@ import localFont from "next/font/local";
 import { League_Gothic } from "next/font/google";
 import { QueryClient, QueryCache, MutationCache } from "@tanstack/query-core";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { ReactNode, useState } from "react";
+import { ReactNode, useRef } from "react";
 import { Toaster } from "react-hot-toast";
 import toast from "react-hot-toast";
 import { ThemeProvider } from "next-themes";
@@ -38,10 +38,34 @@ export default function RootLayout({
   children: ReactNode;
 }>) {
   const router = useRouter();
+  const queryClientRef = useRef<QueryClient | null>(null);
 
-  const handleApiError = (error: Error) => {
+  if (!queryClientRef.current) {
+    queryClientRef.current = new QueryClient({
+      queryCache: new QueryCache({
+        onError: (error) => {
+          void handleApiError(error);
+        },
+      }),
+      mutationCache: new MutationCache({
+        onError: (error) => {
+          void handleApiError(error);
+        },
+      }),
+    });
+  }
+
+  const queryClient = queryClientRef.current;
+
+  const handleApiError = async (error: Error) => {
     if (!(error instanceof ApiError)) {
       return;
+    }
+
+    const qc = queryClientRef.current;
+    if (qc && (error.status === 401 || error.status === 503)) {
+      await qc.cancelQueries({ predicate: () => true });
+      await qc.resetQueries({ predicate: () => true });
     }
 
     if (error.status === 401) {
@@ -69,22 +93,6 @@ export default function RootLayout({
       id: "api-error-toast",
     });
   };
-
-  const [queryClient] = useState(
-    () =>
-      new QueryClient({
-        queryCache: new QueryCache({
-          onError: (error) => {
-            handleApiError(error);
-          },
-        }),
-        mutationCache: new MutationCache({
-          onError: (error) => {
-            handleApiError(error);
-          },
-        }),
-      })
-  );
 
   return (
     <html lang="pl" className="overflow-hidden" suppressHydrationWarning>


### PR DESCRIPTION
401/503 errors left React Query in an error state, causing a brief `ErrorComponent` flash after re-login (these are the errors that redirect to login page).
The fix cancels active queries and resets all query states on 401/503, so after logging in every useQuery starts clean (loading --> data) with no leftover error UI.